### PR TITLE
Improve mobile layout for AboutMe and RecentFilm components

### DIFF
--- a/src/components/AboutMe/AboutMe.css
+++ b/src/components/AboutMe/AboutMe.css
@@ -8,112 +8,114 @@
     padding: 30px;
     margin: 0px 0;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  }
-  
-  .aboutMeContent {
+}
+
+.aboutMeContent {
     flex: 1;
     margin-left: 65px;
     font-family: 'Metal', serif;
     margin-right: 65px;
     font-size: calc(16px + 0.5vw); /* scales with viewport width */
-  }
-  
-  .aboutMeContent h2 {
+}
+
+.aboutMeContent h2 {
     color: #222;
     margin-bottom: 15px;
     font-family: 'Metal', serif;
     font-size: calc(20px + 0.6vw); /* scales with viewport width */
-  }
-  
-  .aboutMeContent p {
+}
+
+.aboutMeContent p {
     color: #555;
     line-height: 1.6;
-  }
-  
-  .aboutMeImage {
+}
+
+.aboutMeImage {
     flex: 1;
     text-align: right;
     margin-right: 55px;
-  }
-  
-  .aboutMeImage img {
+}
+
+.aboutMeImage img {
     width: 75%;
     height: auto;
     border-radius: 2px;
-  }
-  
-  /* Responsive styles */
-  @media (max-width: 768px) {
-    .aboutMeContent, .aboutMeImage {
-      margin-left: 0;
-      margin-right: 0;
-      max-width: 100%;
-    }
-  
-    .aboutMeContent {
-      font-size: calc(14px + 0.5vw); /* smaller base size for smaller viewport */
-    }
-    
-    .aboutMeContent h2 {
-      font-size: calc(18px + 0.5vw); /* smaller base size for smaller viewport */
-    }
-  }
-  
-  @keyframes slide-in {
-    from {
-      transform: translateX(-90px);
-      opacity: 0;
-    }
-    to {
-      transform: translateX(0);
-      opacity: 1;
-    }
-  }
-  
-  @keyframes fade-in {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
-  
-  .slide-in {
-    animation: slide-in 1.5s forwards;
-  }
-  
-  .fade-in {
-    animation: fade-in 2.5s forwards;
-  }
+}
 
-  
-  @media (max-width: 480px) {
+/* Responsive styles */
+@media (max-width: 768px) {
+    .aboutMeContent,
+    .aboutMeImage {
+        margin-left: 0;
+        margin-right: 0;
+        max-width: 100%;
+    }
+
+    .aboutMeContent {
+        font-size: calc(14px + 0.5vw); /* smaller base size for smaller viewport */
+    }
+
+    .aboutMeContent h2 {
+        font-size: calc(18px + 0.5vw); /* smaller base size for smaller viewport */
+    }
+}
+
+@keyframes slide-in {
+    from {
+        transform: translateX(-90px);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+.slide-in {
+    animation: slide-in 1.5s forwards;
+}
+
+.fade-in {
+    animation: fade-in 2.5s forwards;
+}
+
+@media (max-width: 480px) {
     .aboutMeContainer {
         flex-direction: column;
-        }
-        
-        .aboutMeContent, .aboutMeImage {
+    }
+
+    .aboutMeContent,
+    .aboutMeImage {
         max-width: none;
         margin: 0 auto; /* centers the content */
-        }
-        
-        .aboutMeContent h2 {
-        font-size: calc(18px + 1vw); /* slightly larger size for very small viewports */
-        }
-        
-        .aboutMeContent p {
-        font-size: calc(14px + 1vw); /* slightly larger size for very small viewports */
-        }
-        
-        .aboutMeImage img {
-        max-width: 100%; /* make sure image is not larger than the container */
-        }
-        /* Larger screens */
- @media (min-width: 1200px) {
-    .aboutMeImage img {
-      max-width: 30%; /* or any percentage that looks good on large screens */
     }
-  }
+
+    .aboutMeContent h2 {
+        font-size: calc(18px + 1vw); /* slightly larger size for very small viewports */
+    }
+
+    .aboutMeContent p {
+        font-size: calc(14px + 1vw); /* slightly larger size for very small viewports */
+    }
+
+    .aboutMeImage img {
+        max-width: 100%; /* make sure image is not larger than the container */
+    }
 }
-  
+
+/* Larger screens */
+@media (min-width: 1200px) {
+    .aboutMeImage img {
+        max-width: 30%; /* or any percentage that looks good on large screens */
+    }
+}
+

--- a/src/components/RecentFilm/RecentFilm.css
+++ b/src/components/RecentFilm/RecentFilm.css
@@ -23,11 +23,7 @@
   display: flex;
   justify-content: center; /* Center the thumbnails */
   gap: 3rem; /* Adjust the gap between thumbnails */
-}
-
-.film-thumbnail {
-  position: relative; /* Needed for absolute positioning of the caption */
-  width: 300px; /* Adjust the thumbnail width */
+  flex-wrap: wrap; /* Allow thumbnails to wrap on smaller screens */
 }
 
 /* src/components/RecentFilm/RecentFilm.css */
@@ -63,4 +59,18 @@
 .film-thumbnail:hover .film-caption h3,
 .film-thumbnail:hover .film-caption p {
   color: grey; /* Change text color on hover */
+}
+
+/* Stack thumbnails vertically on small screens */
+@media (max-width: 768px) {
+  .film-thumbnails {
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+  }
+
+  .film-thumbnail {
+    width: 100%;
+    max-width: 320px; /* Prevent excessively wide thumbnails */
+  }
 }


### PR DESCRIPTION
## Summary
- Stack RecentFilm thumbnails on small screens and allow wrapping
- Reorganize AboutMe styles with clear media queries for phones and desktops

## Testing
- `CI=true npm test` *(fails: Jest encountered an unexpected token in axios import)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c50196348320aa84553027f6a3df