### PR TITLE
feat: make foto categories responsive

### DIFF
--- a/src/pages/Foto/Foto.css
+++ b/src/pages/Foto/Foto.css
@@ -59,5 +59,24 @@
 .foto-gallery {
   flex: 1; /* Gallery takes up the remaining space */
   overflow-y: auto; /* Allows for scrolling within the gallery if necessary */
-  
+
+}
+
+@media (max-width: 768px) {
+  .foto-container {
+    flex-direction: column;
+  }
+
+  .foto-categories {
+    width: 100%;
+    flex-direction: row;
+    flex: 0 0 auto;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .foto-categories a {
+    display: inline-block;
+    margin: 0 1rem;
+  }
 }


### PR DESCRIPTION
## Summary
- add responsive media query to stack Foto categories horizontally on mobile

## Testing
- `CI=true npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b98fad570483209f5121ca4858e412